### PR TITLE
call the package-safe version of feval (note: this requires Drake)

### DIFF
--- a/add_matlab_unit_tests.pl
+++ b/add_matlab_unit_tests.pl
@@ -24,7 +24,7 @@ while (<$in>) {
 #  $failcondition = "1";   # missing dependency => failure
   $failcondition = "~strncmp(ex.identifier,'Drake:MissingDependency',23)";  # missing dependency => pass
 
-  print $ctestfile "ADD_TEST($testname \"$CMAKE_SOURCE_DIR/cmake/matlab_clean.pl\" \"-nosplash\" \"-nodisplay\" \"-r\" \"rng('shuffle'); rng_state=rng; disp(sprintf('To reproduce this test use rng(%d,''%s'')',rng_state.Seed,rng_state.Type)); disp(' '); addpath('$CMAKE_INSTALL_PREFIX/matlab'); addpath_$POD_NAME; global g_disable_visualizers; g_disable_visualizers=true; try, feval('$test'); catch ex, disp(getReport(ex,'extended')); disp(' '); fprintf('<test_name>$testname</test_name> <error_id>%s</error_id> <error_message>%s</error_message>',ex.identifier,ex.message); disp(' '); force_close_system; exit($failcondition); end; force_close_system; exit(0)\")\n";
+  print $ctestfile "ADD_TEST($testname \"$CMAKE_SOURCE_DIR/cmake/matlab_clean.pl\" \"-nosplash\" \"-nodisplay\" \"-r\" \"rng('shuffle'); rng_state=rng; disp(sprintf('To reproduce this test use rng(%d,''%s'')',rng_state.Seed,rng_state.Type)); disp(' '); addpath('$CMAKE_INSTALL_PREFIX/matlab'); addpath_$POD_NAME; global g_disable_visualizers; g_disable_visualizers=true; try, fevalPackageSafe('$test'); catch ex, disp(getReport(ex,'extended')); disp(' '); fprintf('<test_name>$testname</test_name> <error_id>%s</error_id> <error_message>%s</error_message>',ex.identifier,ex.message); disp(' '); force_close_system; exit($failcondition); end; force_close_system; exit(0)\")\n";
   $props = "WORKING_DIRECTORY \"$testdir\" $props";
   print $ctestfile "SET_TESTS_PROPERTIES($testname PROPERTIES " . $props .")\n";
 }


### PR DESCRIPTION
we need Drake to supply the fevalPackageSafe function which is called in
order to handle Matlab packages, which need special treatment
