### PR TITLE
force compilation against 64-bit mex API

### DIFF
--- a/mex.cmake
+++ b/mex.cmake
@@ -114,7 +114,7 @@ function(mex_setup)
   set(simulink_FOUND ${simulink_FOUND} PARENT_SCOPE)
 
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.c "")
-  execute_process(COMMAND ${mex} -v ${CMAKE_CURRENT_BINARY_DIR}/dummy.c OUTPUT_VARIABLE mexv_output ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${mex} -largeArrayDims -v ${CMAKE_CURRENT_BINARY_DIR}/dummy.c OUTPUT_VARIABLE mexv_output ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
   if ( WIN32 )
     get_mex_option(CC NAMES COMPILER REQUIRED)
     get_mex_option(CXX NAMES COMPILER REQUIRED)


### PR DESCRIPTION
This is required if we want to build sparse MATLAB matrices in mex.