### PR TITLE
Add NO_DEFAULT_PATH to mex find_program call.

### DIFF
--- a/mex.cmake
+++ b/mex.cmake
@@ -102,7 +102,7 @@ function(mex_setup)
   string(STRIP ${_matlab_root} MATLAB_ROOT)
 
   set(matlab "${matlab}" CACHE FILEPATH "${matlab}")
-  find_program(mex NAMES mex mex.bat HINTS ${MATLAB_ROOT}/bin)
+  find_program(mex NAMES mex mex.bat HINTS ${MATLAB_ROOT}/bin NO_DEFAULT_PATH)
   if (NOT mex)
      message(FATAL_ERROR "Failed to find mex executable")
   endif()


### PR DESCRIPTION
Don't even look at environment variables, only look in ${MATLAB_ROOT}/bin.