### PR TITLE
fix setup script on non-mac systems

### DIFF
--- a/pods.cmake
+++ b/pods.cmake
@@ -240,7 +240,7 @@ function(pods_install_bash_setup package)
 
   if (APPLE)
      set(LD_LIBRARY_PATH DYLD_LIBRARY_PATH)
-  elseif()
+  else()
      set(LD_LIBRARY_PATH LD_LIBRARY_PATH)
   endif()
 


### PR DESCRIPTION
the `elseif()` clause was never firing, which resulted in malformed setup scripts on non-apple systems