### PR TITLE
Removed get_relative_path definition in pods.cmake. See issue #1795

### DIFF
--- a/pods.cmake
+++ b/pods.cmake
@@ -35,11 +35,6 @@
 # File: pods.cmake
 # Distributed with pods version: 12.11.14
 
-
-function(get_relative_path from to var)
-  file(RELATIVE_PATH var from to)
-endfunction()
-
 function(call_cygpath format var)
 #  message(STATUS "calling cygpath with ${format} ${${var}}")
 #  message("before cygpath: ${${var}}")


### PR DESCRIPTION
Deleted the definition of get_relative_path in pods.cmake. See discussion in issue RobotLocomotion/drake #1795 and https://github.com/RobotLocomotion/spotless-pod/pull/5.