### PR TITLE
Fix pkg-config paths

### DIFF
--- a/pods.cmake
+++ b/pods.cmake
@@ -86,11 +86,15 @@ macro(pkg_config_path var)
 endmacro()
 
 macro(shell_path var)
-  if (WIN32 AND cygpath AND ${var})
-    # we never want /cygdrive as cmake and other
-    # native tools will not know what that is, so
-    # use -m to get unix paths with drive:
-    call_cygpath(-m ${var})
+  if (WIN32)
+    if (cygpath AND ${var})
+      # we never want /cygdrive as cmake and other
+      # native tools will not know what that is, so
+      # use -m to get unix paths with drive:
+      call_cygpath(-m ${var})
+    else()
+      file(TO_CMAKE_PATH ${${var}} ${var})
+    endif()
   endif()
 endmacro()
 


### PR DESCRIPTION
Change `shell_path helper` function to always convert to forward slashes, not just when `cygpath` is available. This is necessary as `pkg_config_path` always converts to backslashes, and needs to be undone. This fixes errors (e.g. RobotLocomotion/drake#2090) installing the generated .pc files due to 'bad escape sequences' caused by paths having the wrong format.

(Note: as used above, "always" is short for "always (on Windows)"; none of the described path munging occurs on other platforms.)